### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/copy-web-files.yaml
+++ b/.github/workflows/copy-web-files.yaml
@@ -1,4 +1,6 @@
 name: Copy files to destination repo
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GalaxyViewer/GalaxyViewer/security/code-scanning/1](https://github.com/GalaxyViewer/GalaxyViewer/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow (either at the root level or for the specific job). Given this workflow only requires write access to contents (for pushing changes to the destination repo), but uses a PAT for that, it is likely that the `contents: read` permission is sufficient for most steps, and can be safely set as the minimal starting point. If future steps require more granular permissions, they can be added. The change should be made at the root level (just below the `name` and before `on:`) to ensure consistent, minimal privileges for all jobs in the workflow. No changes to imports, job logic, or token usage are needed; only the addition of this YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
